### PR TITLE
fix: Fix the check `->jsonSerialize` which always returns a stdClass,…

### DIFF
--- a/src/OperationDescriber/Describers/RequestDescriber.php
+++ b/src/OperationDescriber/Describers/RequestDescriber.php
@@ -94,9 +94,9 @@ class RequestDescriber implements OperationDescriberInterface
             $attributeInstance = $attribute->newInstance();
 
             if ($attributeInstance instanceof RequestBody) {
-                $attributeData = $attributeInstance->jsonSerialize();
+                $attributeData = (array) $attributeInstance->jsonSerialize();
 
-                assert(is_array($attributeData));
+                assert(is_array($attributeData) && !empty($attributeData));
 
                 Util::createChild($operation, RequestBody::class, $attributeData);
             }

--- a/src/OperationDescriber/Describers/RequestDescriber.php
+++ b/src/OperationDescriber/Describers/RequestDescriber.php
@@ -96,7 +96,9 @@ class RequestDescriber implements OperationDescriberInterface
             if ($attributeInstance instanceof RequestBody) {
                 $attributeData = (array) $attributeInstance->jsonSerialize();
 
-                assert(is_array($attributeData) && !empty($attributeData));
+                if ([] === $attributeData) {
+                    return;
+                }
 
                 Util::createChild($operation, RequestBody::class, $attributeData);
             }

--- a/src/OperationDescriber/Describers/ResponseDescriber.php
+++ b/src/OperationDescriber/Describers/ResponseDescriber.php
@@ -78,9 +78,9 @@ class ResponseDescriber implements OperationDescriberInterface
             $attributeInstance = $attribute->newInstance();
 
             if ($attributeInstance instanceof Response) {
-                $attributeData = $attributeInstance->jsonSerialize();
+                $attributeData = (array) $attributeInstance->jsonSerialize();
 
-                assert(is_array($attributeData));
+                assert(is_array($attributeData) && !empty($attributeData));
 
                 Util::createCollectionItem($operation, 'responses', Response::class, $attributeData);
             }

--- a/src/OperationDescriber/Describers/ResponseDescriber.php
+++ b/src/OperationDescriber/Describers/ResponseDescriber.php
@@ -80,7 +80,9 @@ class ResponseDescriber implements OperationDescriberInterface
             if ($attributeInstance instanceof Response) {
                 $attributeData = (array) $attributeInstance->jsonSerialize();
 
-                assert(is_array($attributeData) && !empty($attributeData));
+                if ([] === $attributeData) {
+                    return;
+                }
 
                 Util::createCollectionItem($operation, 'responses', Response::class, $attributeData);
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4a19e4be-5543-4ecc-8eed-8b6f1246b2e2)

Currently if you try to use open api attributes on response/request an error get's thrown when running `php artisan swagger:generate`


```
   AssertionError 

  assert(is_array($attributeData))

  at vendor/kr0lik/laravel-dto-to-swagger/src/OperationDescriber/Describers/ResponseDescriber.php:83
     79▕ 
     80▕             if ($attributeInstance instanceof Response) {
     81▕                 $attributeData = $attributeInstance->jsonSerialize();
     82▕ 
  ➜  83▕                 assert(is_array($attributeData));
     84▕ 
     85▕                 Util::createCollectionItem($operation, 'responses', Response::class, $attributeData);
     86▕             }
     87▕         }

      +19 vendor frames 

  20  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```


This PR just updates the assertions for these attributes to hopefully be more accurate. As `->jsonSerialize();` always returns a stdClass, the current  `assert(is_array($attributeData));` will always fail