### PR TITLE
Extract required info from file upload type

### DIFF
--- a/src/OperationDescriber/Describers/RequestDescriber.php
+++ b/src/OperationDescriber/Describers/RequestDescriber.php
@@ -67,12 +67,12 @@ class RequestDescriber implements OperationDescriberInterface
 
             $fileUploadProperties = $this->searchFileUploadProperties($types[0]);
 
-            if ([] !== $fileUploadProperties) {
+            if ([] !== $fileUploadProperties['properties']) {
                 $contentType = 'multipart/form-data';
 
                 $multipartSchema = new Schema([
                     'type' => 'object',
-                    'properties' => $fileUploadProperties,
+                    ...$fileUploadProperties
                 ]);
 
                 if ($this->isNotEmpty($mainSchema)) {
@@ -202,7 +202,13 @@ class RequestDescriber implements OperationDescriberInterface
 
         $fileUploadProperties = [];
 
+        $requiredProperties = [];
+
         foreach (ClassHelper::getVisiblePropertiesRecursively($reflectionClass) as $reflectionProperty) {
+            if ($this->isRequired($reflectionProperty)) {
+                $requiredProperties[] = $reflectionProperty->getName();
+            }
+
             if (
                 $reflectionProperty->getType() instanceof ReflectionNamedType
                 && (
@@ -218,7 +224,7 @@ class RequestDescriber implements OperationDescriberInterface
             }
         }
 
-        return $fileUploadProperties;
+        return ['properties' => $fileUploadProperties, 'required' => $requiredProperties];
     }
 
     private function isNotEmpty(Schema $schema): bool


### PR DESCRIPTION
Suppose I have this
```php
class CreateSomethingDto extends Data implements JsonRequestInterface
{
    public function __construct(
        #[File]
        public UploadedFile $file,

        #[Image]
        public ?UploadedFile $logo = null,
    ) {}
}
```
in current implementation, both file and logo will be nullable. This PR will extract the required information from file upload type then append in required array in the describer so only logo will be optional in describer